### PR TITLE
Change the default up directory + .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+# Byte-compiled / optimized / DLL Python files
+__pycache__/
+*.py[cod]
+*$py.class

--- a/file_sync_up/config.py
+++ b/file_sync_up/config.py
@@ -1,2 +1,2 @@
 server_url = "http://localhost:8000"
-sync_folder_location = "Files"
+sync_folder_location = "file_sync_output"


### PR DESCRIPTION
Now that this repository is a submodule of the driver IO (see [this](https://github.com/badgerloop-software/sc1-driver-io/pull/32)), it makes sense for the default upload directory to reference the driver IO output directory.

I also added a .gitignore since I didn't see one already